### PR TITLE
Use nixpkgs rust platform

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,27 +48,10 @@
         "type": "github"
       }
     },
-    "patched-nixpkgs": {
-      "locked": {
-        "lastModified": 1751581788,
-        "narHash": "sha256-oYHn5qiRNkWE35VQqoeeZQZ+vr89kyUFyAPb0yD3HaI=",
-        "owner": "TomaSajt",
-        "repo": "nixpkgs",
-        "rev": "cce9f4e9da34ceea0efa7ad7588256643f4da012",
-        "type": "github"
-      },
-      "original": {
-        "owner": "TomaSajt",
-        "ref": "fetch-cargo-vendor-dup",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "patched-nixpkgs": "patched-nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -51,7 +51,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
-    patched-nixpkgs.url = "github:TomaSajt/nixpkgs?ref=fetch-cargo-vendor-dup";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
@@ -28,14 +27,12 @@
           self',
           inputs',
           ...
-        }: let
-          rustPlatform = inputs'.patched-nixpkgs.legacyPackages.rustPlatform;
-        in {
+        }: {
           packages = {
-            zed-editor = pkgs.callPackage ./packages/zed-editor {rustPlatform = rustPlatform;};
+            zed-editor = pkgs.callPackage ./packages/zed-editor {};
             zed-editor-fhs = self'.packages.zed-editor.passthru.fhs;
 
-            zed-editor-preview = pkgs.callPackage ./packages/zed-editor-preview {rustPlatform = rustPlatform;};
+            zed-editor-preview = pkgs.callPackage ./packages/zed-editor-preview {};
             zed-editor-preview-fhs = self'.packages.zed-editor-preview.passthru.fhs;
 
             zed-editor-bin = pkgs.callPackage ./packages/zed-editor-bin {};

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,6 @@
   outputs = inputs @ {
     flake-parts,
     nixpkgs,
-    patched-nixpkgs,
     ...
   }:
     flake-parts.lib.mkFlake {inherit inputs;} (


### PR DESCRIPTION
Removed the now unnecessary outsourced rustPlatform. The patch that was implemented there has since been upstreamed.