### PR TITLE
Add glib dependency

### DIFF
--- a/packages/zed-editor-bin/default.nix
+++ b/packages/zed-editor-bin/default.nix
@@ -11,6 +11,7 @@
   libxkbcommon,
   zlib,
   alsa-lib,
+  glib,
   wayland,
   vulkan-loader,
   buildFHSEnv,
@@ -67,6 +68,7 @@
     libxkbcommon
     zlib
     alsa-lib
+    glib
     wayland
     vulkan-loader
   ];

--- a/packages/zed-editor-preview-bin/default.nix
+++ b/packages/zed-editor-preview-bin/default.nix
@@ -11,6 +11,7 @@
   libxkbcommon,
   zlib,
   alsa-lib,
+  glib,
   wayland,
   vulkan-loader,
   buildFHSEnv,
@@ -67,6 +68,7 @@
     libxkbcommon
     zlib
     alsa-lib
+    glib
     wayland
     vulkan-loader
   ];

--- a/packages/zed-editor-preview/default.nix
+++ b/packages/zed-editor-preview/default.nix
@@ -16,6 +16,7 @@
   zlib,
   zstd,
   alsa-lib,
+  glib,
   libxkbcommon,
   wayland,
   libglvnd,
@@ -160,6 +161,7 @@ in
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [
         alsa-lib
+        glib
         libxkbcommon
         wayland
         xorg.libxcb

--- a/packages/zed-editor/default.nix
+++ b/packages/zed-editor/default.nix
@@ -16,6 +16,7 @@
   zlib,
   zstd,
   alsa-lib,
+  glib,
   libxkbcommon,
   wayland,
   libglvnd,
@@ -160,6 +161,7 @@ in
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [
         alsa-lib
+        glib
         libxkbcommon
         wayland
         xorg.libxcb


### PR DESCRIPTION
This seems needed starting with zed 2.231.0 at least. Otherwise it errors out on startup because it cannot find `libgio`.